### PR TITLE
Fix BLPOP and BRPOP arguments constructing

### DIFF
--- a/main.go
+++ b/main.go
@@ -371,6 +371,9 @@ func setReplyValue(v reflect.Value, raw unsafe.Pointer) error {
 		case reflect.Uint64:
 			// string -> uint64
 			v.Set(reflect.ValueOf(to.Uint64(s)))
+		case reflect.Bool:
+			// string -> bool
+			v.Set(reflect.ValueOf(to.Bool(s)))
 		default:
 			return fmt.Errorf("Unsupported conversion: redis string to %v", v.Kind())
 		}


### PR DESCRIPTION
BLPOP and BRPOP commands  do not correctly construct their arguments. The _i_ variable is not getting increased in the range loop and timeout arg is getting placed in the first position instead of the last.
