### PR TITLE
ConfigGet to return []string

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -275,8 +275,8 @@ while Redis 2.6 can read the whole configuration of a server using this command.
 
 http://redis.io/commands/config-get
 */
-func (c *Client) ConfigGet(parameter string) (string, error) {
-	var ret string
+func (c *Client) ConfigGet(parameter string) ([]string, error) {
+	var ret []string
 	err := c.command(
 		&ret,
 		[]byte("CONFIG"),


### PR DESCRIPTION
The original ConfigGet() API returned (string, error) which resulted in an error if the
config parameter needed to return an array of values.  Therefore modifying the API to
return ([]string, error)
